### PR TITLE
Parse/source arguments via keystoneauth

### DIFF
--- a/openstacknagios/ceilometer/Statistics.py
+++ b/openstacknagios/ceilometer/Statistics.py
@@ -26,7 +26,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from ceilometerclient.client import Client
+from ceilometerclient import client
 
 import datetime
 from pytz import timezone
@@ -49,7 +49,7 @@ class CeilometerStatistics(osnag.Resource):
 
     def probe(self):
         try:
-           ceilometer = ceilclient.Client(self.api_version, session=self.session)
+           ceilometer = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error('cannot start ceil ' + str(e))
 

--- a/openstacknagios/ceilometer/Statistics.py
+++ b/openstacknagios/ceilometer/Statistics.py
@@ -49,7 +49,7 @@ class CeilometerStatistics(osnag.Resource):
 
     def probe(self):
         try:
-           ceilometer = ceilclient.Client('2', session=self.session)
+           ceilometer = ceilclient.Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error('cannot start ceil ' + str(e))
 

--- a/openstacknagios/cinder/Services.py
+++ b/openstacknagios/cinder/Services.py
@@ -36,7 +36,7 @@ class CinderServices(osnag.Resource):
 
     def probe(self):
         try:
-           cinder=Client('2', session=self.session)
+           cinder=Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/cinder/Services.py
+++ b/openstacknagios/cinder/Services.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
   Nagios/Icinga plugin to check running cinder agents/services.
@@ -23,40 +23,29 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-
 from cinderclient.client import Client
-
 
 class CinderServices(osnag.Resource):
     """
     Determines the status of the cinder agents/services.
     """
-
     def __init__(self, binary=None, host=None, args=None):
         self.binary = binary
         self.host   = host
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
-
         try:
-           cinder=Client('2', self.openstack['username'],
-                              self.openstack['password'], 
-                              self.openstack['tenant_name'], 
-                              self.openstack['auth_url'],
-                              insecure=self.openstack['insecure'],
-                              region_name=self.openstack['region_name'],
-                              cacert=self.openstack['cacert'])
+           cinder=Client('2', session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 
         try:
-           result=cinder.services.list()
+           result = cinder.services.list()
         except Exception as e:
            self.exit_error(str(e))
 
-        stati=dict(up=0, disabled=0, down=0, total=0)
+        stati = dict(up=0, disabled=0, down=0, total=0)
 
         for agent in result:
            if (self.host == None or self.host == agent.host) and (self.binary == None or self.binary == agent.binary):
@@ -89,11 +78,11 @@ def main():
     argp.add_argument( '--critical_down', metavar='RANGE', default='0',
                       help='return critical if number of down agents is outside RANGE (default: 0, always critical if any')
 
-    argp.add_argument('--binary', 
+    argp.add_argument('--binary',
                     dest='binary',
                     default=None,
                     help='filter agent binary')
-    argp.add_argument('--host', 
+    argp.add_argument('--host',
                     dest='host',
                     default=None,
                     help='filter hostname')
@@ -106,11 +95,8 @@ def main():
         osnag.ScalarContext('disabled', args.warn_disabled, args.critical_disabled),
         osnag.ScalarContext('down', args.warn_down, args.critical_down),
         osnag.ScalarContext('total', '0:', '@0'),
-        osnag.Summary(show=['up','disabled','down','total'])
-        )
+        osnag.Summary(show=['up','disabled','down','total']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-
-

--- a/openstacknagios/cinder/Services.py
+++ b/openstacknagios/cinder/Services.py
@@ -23,7 +23,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from cinderclient.client import Client
+from cinderclient import client
 
 class CinderServices(osnag.Resource):
     """
@@ -36,7 +36,7 @@ class CinderServices(osnag.Resource):
 
     def probe(self):
         try:
-           cinder=Client(self.api_version, session=self.session)
+           cinder=client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/ironic/Nodes.py
+++ b/openstacknagios/ironic/Nodes.py
@@ -23,18 +23,12 @@
 """
 
 import subprocess
-
 import openstacknagios.openstacknagios as osnag
 
 class IronicNodes(osnag.Resource):
     """
     Determines the status of the ironic nodes.
-
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-
     def probe(self):
         # Getting the Python Ironic client to talk SSL is a dark art
         # Use the command line client instead
@@ -46,7 +40,7 @@ class IronicNodes(osnag.Resource):
 
         lines = out.splitlines()[1:]
 
-        stati=dict(maintenance=0, total=0)
+        stati = dict(maintenance=0, total=0)
 
         for node in lines:
            stati['total'] += 1
@@ -71,8 +65,7 @@ def main():
         IronicNodes(args=args),
         osnag.ScalarContext('maintenance', args.warn, args.critical),
         osnag.ScalarContext('total', '0:', '@0'),
-        osnag.Summary(show=['maintenance','total'])
-        )
+        osnag.Summary(show=['maintenance','total']))
     check.main(verbose=args.verbose,  timeout=args.timeout)
 
 if __name__ == '__main__':

--- a/openstacknagios/keystone/Endpoints.py
+++ b/openstacknagios/keystone/Endpoints.py
@@ -21,37 +21,22 @@
  The check will list endpoints and warn if there are more than expected.
 """
 
-import json
-import time
 import openstacknagios.openstacknagios as osnag
-
-import keystoneclient.v2_0.client as ksclient
-
+from keystoneclient.client import Client
 
 class KeystoneEndpoints(osnag.Resource):
     """
     Nagios/Icinga plugin to check keystone.
-
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
 
     def probe(self):
         try:
-           keystone=ksclient.Client(username    = self.openstack['username'],
-                                    password    = self.openstack['password'],
-                                    tenant_name = self.openstack['tenant_name'],
-                                    auth_url    = self.openstack['auth_url'],
-                                    cacert      = self.openstack['cacert'],
-                                    region_name = self.openstack['region_name'],
-                                    insecure    = self.openstack['insecure'])
+           client = Client(session=self.session)
         except Exception as e:
            self.exit_error('cannot create keystone client')
 
         try:
-            endpoints = keystone.service_catalog.get_endpoints()
+            endpoints = client.service_catalog.get_endpoints()
         except Exception as e:
             self.exit_error('cannot get endpoints')
 
@@ -72,10 +57,8 @@ def main():
     check = osnag.Check(
         KeystoneEndpoints(args=args),
         osnag.ScalarContext('endpoints', args.warn, args.critical),
-        osnag.Summary(show=['endpoints'])
-        )
+        osnag.Summary(show=['endpoints']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/keystone/Endpoints.py
+++ b/openstacknagios/keystone/Endpoints.py
@@ -22,7 +22,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from keystoneclient.client import Client
+from keystoneclient import client
 
 class KeystoneEndpoints(osnag.Resource):
     """
@@ -31,14 +31,16 @@ class KeystoneEndpoints(osnag.Resource):
 
     def probe(self):
         try:
-           client = Client(session=self.session)
+           keystone = client.Client(version=self.api_version,
+                                    interface='public', session=self.session,
+                                    region_name=self.region_name)
         except Exception as e:
-           self.exit_error('cannot create keystone client')
+           self.exit_error('cannot create keystone client: ' + str(e))
 
         try:
-            endpoints = client.service_catalog.get_endpoints()
+            endpoints = keystone.endpoints.list()
         except Exception as e:
-            self.exit_error('cannot get endpoints')
+            self.exit_error('cannot get endpoints: ' + str(e))
 
         yield osnag.Metric('endpoints', len(endpoints), min=0)
 

--- a/openstacknagios/keystone/Token.py
+++ b/openstacknagios/keystone/Token.py
@@ -33,7 +33,7 @@ class KeystoneToken(osnag.Resource):
     def probe(self):
         start = time.time()
         try:
-           Client(session=self.session)
+           Client(session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error('cannot get token')
 

--- a/openstacknagios/keystone/Token.py
+++ b/openstacknagios/keystone/Token.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
  Nagios/Icinga plugin to check keystone.
@@ -22,33 +22,18 @@
  time used.
 """
 
-import json
 import time
 import openstacknagios.openstacknagios as osnag
-
-import keystoneclient.v2_0.client as ksclient
-
+from keystoneclient.client import Client
 
 class KeystoneToken(osnag.Resource):
     """
     Nagios/Icinga plugin to check keystone.
-
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
-
     def probe(self):
         start = time.time()
         try:
-           keystone=ksclient.Client(username    = self.openstack['username'],
-                                    password    = self.openstack['password'],
-                                    tenant_name = self.openstack['tenant_name'],
-                                    auth_url    = self.openstack['auth_url'],
-                                    cacert      = self.openstack['cacert'],
-                                    region_name = self.openstack['region_name'],
-                                    insecure    = self.openstack['insecure'])
+           Client(session=self.session)
         except Exception as e:
            self.exit_error('cannot get token')
 
@@ -57,8 +42,6 @@ class KeystoneToken(osnag.Resource):
         yield osnag.Metric('gettime', get_time-start, min=0)
 
 
-
-         
 @osnag.guarded
 def main():
     argp = osnag.ArgumentParser(description=__doc__)
@@ -73,10 +56,8 @@ def main():
     check = osnag.Check(
         KeystoneToken(args=args),
         osnag.ScalarContext('gettime', args.warn, args.critical),
-        osnag.Summary(show=['gettime'])
-        )
+        osnag.Summary(show=['gettime']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/neutron/Agents.py
+++ b/openstacknagios/neutron/Agents.py
@@ -35,7 +35,7 @@ class NeutronAgents(osnag.Resource):
 
     def probe(self):
         try:
-           neutron = Client('2.0', session=self.session)
+           neutron = Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/neutron/Agents.py
+++ b/openstacknagios/neutron/Agents.py
@@ -22,7 +22,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from neutronclient.neutron.client import Client
+from neutronclient.neutron import client
 
 class NeutronAgents(osnag.Resource):
     """
@@ -35,14 +35,14 @@ class NeutronAgents(osnag.Resource):
 
     def probe(self):
         try:
-           neutron = Client(self.api_version, session=self.session)
+           neutron = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 
         try:
-           result = neutron.list_agents(host=self.host,binary=self.binary)
+           result = neutron.list_agents(host=self.host, binary=self.binary)
         except Exception as e:
-           self.exit_error(str(e))
+           self.exit_error('list_agents: ' + str(e))
 
         stati = dict(up=0, disabled=0, down=0, total=0)
 

--- a/openstacknagios/neutron/Agents.py
+++ b/openstacknagios/neutron/Agents.py
@@ -14,60 +14,37 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
  Nagios/Icinga plugin to check running neutron agents.
  This corresponds to the output of 'neutron agent-list'.
 """
 
-import json
 import openstacknagios.openstacknagios as osnag
-
-import keystoneclient.v2_0.client as ksclient
-
-from neutronclient.neutron import client
-
+from neutronclient.neutron.client import Client
 
 class NeutronAgents(osnag.Resource):
     """
     Determines the status of the neutron agents.
-
     """
-
     def __init__(self, binary=None, host=None, args=None):
         self.binary    = binary
         self.host      = host
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
         try:
-           keystone=ksclient.Client(username    = self.openstack['username'],
-                                    password    = self.openstack['password'],
-                                    tenant_name = self.openstack['tenant_name'],
-                                    auth_url    = self.openstack['auth_url'],
-                                    cacert      = self.openstack['cacert'],
-                                    region_name = self.openstack['region_name'],
-                                    insecure    = self.openstack['insecure'])
-        except Exception as e:
-           self.exit_error('cannot get token ' + str(e))
-         
-        try:
-           neutron = client.Client('2.0', endpoint_url = keystone.service_catalog.url_for(endpoint_type='public',service_type='network'),
-                                          token        = keystone.auth_token,
-                                          ca_cert      = self.openstack['cacert'],
-                                          region_name  = self.openstack['region_name'],
-                                          insecure     = self.openstack['insecure'])
+           neutron = Client('2.0', session=self.session)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 
         try:
-           result=neutron.list_agents(host=self.host,binary=self.binary)
+           result = neutron.list_agents(host=self.host,binary=self.binary)
         except Exception as e:
            self.exit_error(str(e))
 
-        stati=dict(up=0, disabled=0, down=0, total=0)
+        stati = dict(up=0, disabled=0, down=0, total=0)
 
         for agent in result['agents']:
            stati['total'] += 1
@@ -100,11 +77,11 @@ def main():
     argp.add_argument( '--critical_down', metavar='RANGE', default='0',
                       help='return critical if number of down agents is outside RANGE (default: 0, always critical if any')
 
-    argp.add_argument('--binary', 
+    argp.add_argument('--binary',
                     dest='binary',
                     default='',
                     help='filter agent binary')
-    argp.add_argument('--host', 
+    argp.add_argument('--host',
                     dest='host',
                     default='',
                     help='filter hostname')
@@ -117,10 +94,8 @@ def main():
         osnag.ScalarContext('disabled', args.warn_disabled, args.critical_disabled),
         osnag.ScalarContext('down', args.warn_down, args.critical_down),
         osnag.ScalarContext('total', '0:', '@0'),
-        osnag.Summary(show=['up','disabled','down'])
-        )
+        osnag.Summary(show=['up','disabled','down']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/neutron/Floatingips.py
+++ b/openstacknagios/neutron/Floatingips.py
@@ -31,7 +31,7 @@ class NeutronFloatingips(osnag.Resource):
     """
     def probe(self):
         try:
-           neutron = Client('2.0', session=self.session)
+           neutron = Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/neutron/Floatingips.py
+++ b/openstacknagios/neutron/Floatingips.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 """
    Nagios/Icinga plugin to check floating ip's.
    Counts the assigned ip's (= used + unused).
@@ -23,48 +23,20 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-
-import json
-
-import keystoneclient.v2_0.client as ksclient
-
-from neutronclient.neutron import client
-
-
+from neutronclient.neutron.client import Client
 
 class NeutronFloatingips(osnag.Resource):
     """
     Determines the number of assigned (used and unused) floating ip's
-
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
-
     def probe(self):
         try:
-           keystone=ksclient.Client(username    = self.openstack['username'],
-                                    password    = self.openstack['password'],
-                                    tenant_name = self.openstack['tenant_name'],
-                                    auth_url    = self.openstack['auth_url'],
-                                    cacert      = self.openstack['cacert'],
-                                    region_name = self.openstack['region_name'],
-                                    insecure    = self.openstack['insecure'])
-        except Exception as e:
-           self.exit_error('cannot get token ' + str(e))
-         
-        try:
-           neutron = client.Client('2.0', endpoint_url = keystone.service_catalog.url_for(endpoint_type='public',service_type='network'),
-                                          token        = keystone.auth_token, 
-                                          ca_cert      = self.openstack['cacert'],
-                                          region_name  = self.openstack['region_name'],
-                                          insecure     = self.openstack['insecure'])
+           neutron = Client('2.0', session=self.session)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 
         try:
-           result=neutron.list_floatingips()
+           result = neutron.list_floatingips()
         except Exception as e:
            self.exit_error(str(e))
 
@@ -100,4 +72,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/neutron/Floatingips.py
+++ b/openstacknagios/neutron/Floatingips.py
@@ -23,7 +23,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from neutronclient.neutron.client import Client
+from neutronclient.neutron import client
 
 class NeutronFloatingips(osnag.Resource):
     """
@@ -31,7 +31,7 @@ class NeutronFloatingips(osnag.Resource):
     """
     def probe(self):
         try:
-           neutron = Client(self.api_version, session=self.session)
+           neutron = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error('cannot load ' + str(e))
 
@@ -66,8 +66,7 @@ def main():
         NeutronFloatingips(args=args),
         osnag.ScalarContext('assigned', args.warn, args.critical),
         osnag.ScalarContext('used'),
-        osnag.Summary(show=['assigned','used'])
-        )
+        osnag.Summary(show=['assigned','used']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':

--- a/openstacknagios/neutron/Networkipavailabilities.py
+++ b/openstacknagios/neutron/Networkipavailabilities.py
@@ -31,7 +31,7 @@ class NeutronNetworkipavailabilities(osnag.Resource):
 
     def probe(self):
         try:
-            neutron = Client('2.0', session=self.session)
+            neutron = Client(self.api_version, session=self.session)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/neutron/Networkipavailabilities.py
+++ b/openstacknagios/neutron/Networkipavailabilities.py
@@ -19,7 +19,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from neutronclient.neutron.client import Client
+from neutronclient.neutron import client
 
 class NeutronNetworkipavailabilities(osnag.Resource):
     """
@@ -31,7 +31,7 @@ class NeutronNetworkipavailabilities(osnag.Resource):
 
     def probe(self):
         try:
-            neutron = Client(self.api_version, session=self.session)
+            neutron = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/neutron/Networkipavailabilities.py
+++ b/openstacknagios/neutron/Networkipavailabilities.py
@@ -11,7 +11,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 """
    Nagios/Icinga plugin to check available ip's.
 
@@ -19,47 +19,30 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-import keystoneclient.v2_0.client as ksclient
-from neutronclient.neutron import client
+from neutronclient.neutron.client import Client
 
 class NeutronNetworkipavailabilities(osnag.Resource):
     """
     Determines the number of total and used neutron network ip's
-
     """
-
-    def __init__(self, args=None):
-        self.network_uuid = args.network_uuid
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
+    def __init__(self, network_uuid=None, args=None):
+        self.network_uuid = network_uuid
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
         try:
-            keystone=ksclient.Client(username    = self.openstack['username'],
-                                    password    = self.openstack['password'],
-                                    tenant_name = self.openstack['tenant_name'],
-                                    auth_url    = self.openstack['auth_url'],
-                                    cacert      = self.openstack['cacert'],
-                                    insecure    = self.openstack['insecure'])
-        except Exception as e:
-            self.exit_error('cannot get token ' + str(e))
-         
-        try:
-            neutron = client.Client('2.0', endpoint_url = keystone.service_catalog.url_for(endpoint_type='public',service_type='network'),
-                                          token        = keystone.auth_token, 
-                                          ca_cert      = self.openstack['cacert'],
-                                          insecure     = self.openstack['insecure'])
+            neutron = Client('2.0', session=self.session)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 
         try:
-            result=neutron.show_network_ip_availability(self.network_uuid)
+            result = neutron.show_network_ip_availability(self.network_uuid)
         except Exception as e:
             self.exit_error(str(e))
 
-        net_ip = result['network_ip_availability'] 
+        net_ip = result['network_ip_availability']
 
-        stati=dict(total=0, used=0)
+        stati = dict(total=0, used=0)
         stati['total'] = net_ip['total_ips']
         stati['used'] = net_ip['used_ips']
 
@@ -78,13 +61,11 @@ def main():
     args = argp.parse_args()
 
     check = osnag.Check(
-        NeutronNetworkipavailabilities(args=args),
+        NeutronNetworkipavailabilities(network_uuid=args.network_uuid, args=args),
         osnag.ScalarContext('total'),
         osnag.ScalarContext('used', args.warn, args.critical),
-        osnag.Summary(show=['total','used'])
-        )
+        osnag.Summary(show=['total','used']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/neutron/Routers.py
+++ b/openstacknagios/neutron/Routers.py
@@ -33,7 +33,7 @@ class NeutronRouters(osnag.Resource):
 
     def probe(self):
         try:
-            neutron = Client('2.0', session=self.session)
+            neutron = Client(self.api_version, session=self.session)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/neutron/Routers.py
+++ b/openstacknagios/neutron/Routers.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 """
    Nagios plugin to check router status. Router status is an extended feature
    provided to neutron via astara. https://github.com/openstack/astara . This
@@ -24,41 +24,16 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-
-import keystoneclient.v2_0.client as ks
-
-from neutronclient.neutron import client
-
+from neutronclient.neutron.client import Client
 
 class NeutronRouters(osnag.Resource):
     """
     Determines the number down/build/active routers
-
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
 
     def probe(self):
         try:
-            k = ks.Client(username=self.openstack['username'],
-                          password=self.openstack['password'],
-                          tenant_name=self.openstack['tenant_name'],
-                          auth_url=self.openstack['auth_url'],
-                          cacert=self.openstack['cacert'],
-                          insecure=self.openstack['insecure'])
-        except Exception as e:
-            self.exit_error('cannot get token ' + str(e))
-         
-        try:
-            neutron = client.Client('2.0',
-                                    endpoint_url=k.service_catalog.url_for(
-                                        endpoint_type='public',
-                                        service_type='network'),
-                                    token=k.auth_token, 
-                                    ca_cert=self.openstack['cacert'],
-                                    insecure=self.openstack['insecure'])
+            neutron = Client('2.0', session=self.session)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 
@@ -105,10 +80,8 @@ def main():
         osnag.ScalarContext('active'),
         osnag.ScalarContext('down', args.warn, args.critical),
         osnag.ScalarContext('build', args.warn_build, args.critical_build),
-        osnag.Summary(show=['active', 'down', 'build'])
-        )
+        osnag.Summary(show=['active', 'down', 'build']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/neutron/Routers.py
+++ b/openstacknagios/neutron/Routers.py
@@ -24,7 +24,7 @@
 """
 
 import openstacknagios.openstacknagios as osnag
-from neutronclient.neutron.client import Client
+from neutronclient.neutron import client
 
 class NeutronRouters(osnag.Resource):
     """
@@ -33,7 +33,7 @@ class NeutronRouters(osnag.Resource):
 
     def probe(self):
         try:
-            neutron = Client(self.api_version, session=self.session)
+            neutron = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
             self.exit_error('cannot load ' + str(e))
 

--- a/openstacknagios/nova/Hypervisors.py
+++ b/openstacknagios/nova/Hypervisors.py
@@ -35,7 +35,7 @@ class NovaHypervisors(osnag.Resource):
 
     def probe(self):
         try:
-           nova = Client('2', session=self.session)
+           nova = Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/nova/Hypervisors.py
+++ b/openstacknagios/nova/Hypervisors.py
@@ -21,9 +21,8 @@
     This corresponds to the output of 'nova hypervisor-stats'
 """
 
-from novaclient.client import Client
-
 import openstacknagios.openstacknagios as osnag
+from novaclient import client
 
 class NovaHypervisors(osnag.Resource):
     """
@@ -35,7 +34,7 @@ class NovaHypervisors(osnag.Resource):
 
     def probe(self):
         try:
-           nova = Client(self.api_version, session=self.session)
+           nova = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/nova/Hypervisors.py
+++ b/openstacknagios/nova/Hypervisors.py
@@ -14,9 +14,9 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
-""" 
+"""
     Nagios/Icinga plugin to check nova hypervisors.
     This corresponds to the output of 'nova hypervisor-stats'
 """
@@ -28,31 +28,22 @@ import openstacknagios.openstacknagios as osnag
 class NovaHypervisors(osnag.Resource):
     """
     Determines the status of the nova hypervisors.
-
     """
-
     def __init__(self, host=None, args=None):
-        self.host   = host
-        self.openstack = self.get_openstack_vars(args=args)
+        self.host = host
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
         try:
-           nova=Client('2', self.openstack['username'],
-                            self.openstack['password'], 
-                            self.openstack['tenant_name'],
-                            auth_url    = self.openstack['auth_url'],
-                            cacert      = self.openstack['cacert'],
-                            region_name = self.openstack['region_name'],
-                            insecure    = self.openstack['insecure'])
-
+           nova = Client('2', session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 
         try:
            if self.host:
-              result=nova.hypervisors.get(nova.hypervisors.find(hypervisor_hostname=self.host))
+              result = nova.hypervisors.get(nova.hypervisors.find(hypervisor_hostname=self.host))
            else:
-              result=nova.hypervisors.statistics()
+              result = nova.hypervisors.statistics()
         except Exception as e:
            self.exit_error(str(e))
 
@@ -104,10 +95,8 @@ def main():
         osnag.ScalarContext('vcpus_percent', args.warn_vcpus_percent, args.critical_vcpus_percent),
         osnag.ScalarContext('memory_used', args.warn_memory, args.critical_memory),
         osnag.ScalarContext('memory_percent', args.warn_memory_percent, args.critical_memory_percent),
-        osnag.Summary(show=['memory_used','memory_percent', 'vcpus_used','vcpus_percent','running_vms'])
-        )
+        osnag.Summary(show=['memory_used','memory_percent', 'vcpus_used','vcpus_percent','running_vms']))
     check.main(verbose=args.verbose,  timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-

--- a/openstacknagios/nova/Images.py
+++ b/openstacknagios/nova/Images.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
     Nagios plugin to check running nova images.
@@ -24,27 +24,18 @@ import time
 import openstacknagios.openstacknagios as osnag
 
 from novaclient.client import Client
+from novaclient.v2 import images
 
 
 class NovaImages(osnag.Resource):
     """
         Lists nova images and gets timing
     """
-
-    def __init__(self, args=None):
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
-
     def probe(self):
         start = time.time()
         try:
-            nova = Client('2', self.openstack['username'], 
-                          self.openstack['password'], 
-                          self.openstack['tenant_name'],
-                          auth_url=self.openstack['auth_url'],
-                          cacert=self.openstack['cacert'],
-                          insecure=self.openstack['insecure'])
-            nova.images.list()
+            nova = Client('2', session=self.session)
+            images.GlanceManager(nova).list()
         except Exception as e:
             self.exit_error(str(e))
 
@@ -65,10 +56,10 @@ def main():
     args = argp.parse_args()
 
     check = osnag.Check(
-        NovaImages(args=args),
+        NovaImages(args),
         osnag.ScalarContext('gettime', args.warn, args.critical),
         osnag.Summary(show=['gettime'])
-        )
+    )
     check.main(verbose=args.verbose,  timeout=args.timeout)
 
 if __name__ == '__main__':

--- a/openstacknagios/nova/Images.py
+++ b/openstacknagios/nova/Images.py
@@ -54,7 +54,7 @@ def main():
     args = argp.parse_args()
 
     check = osnag.Check(
-        NovaImages(args),
+        NovaImages(args=args),
         osnag.ScalarContext('gettime', args.warn, args.critical),
         osnag.Summary(show=['gettime'])
     )

--- a/openstacknagios/nova/Images.py
+++ b/openstacknagios/nova/Images.py
@@ -22,10 +22,8 @@
 
 import time
 import openstacknagios.openstacknagios as osnag
-
-from novaclient.client import Client
+from novaclient import client
 from novaclient.v2 import images
-
 
 class NovaImages(osnag.Resource):
     """
@@ -34,7 +32,7 @@ class NovaImages(osnag.Resource):
     def probe(self):
         start = time.time()
         try:
-            nova = Client(self.api_version, session=self.session)
+            nova = client.Client(self.api_version, session=self.session, region_name=self.region_name)
             images.GlanceManager(nova).list()
         except Exception as e:
             self.exit_error(str(e))

--- a/openstacknagios/nova/Images.py
+++ b/openstacknagios/nova/Images.py
@@ -34,7 +34,7 @@ class NovaImages(osnag.Resource):
     def probe(self):
         start = time.time()
         try:
-            nova = Client('2', session=self.session)
+            nova = Client(self.api_version, session=self.session)
             images.GlanceManager(nova).list()
         except Exception as e:
             self.exit_error(str(e))

--- a/openstacknagios/nova/Services.py
+++ b/openstacknagios/nova/Services.py
@@ -22,9 +22,8 @@
     This corresponds to the output of 'nova service-list'.
 """
 
+from novaclient import client
 import openstacknagios.openstacknagios as osnag
-
-from novaclient.client import Client
 
 class NovaServices(osnag.Resource):
     """
@@ -37,7 +36,7 @@ class NovaServices(osnag.Resource):
 
     def probe(self):
         try:
-           nova = Client(self.api_version, session=self.session)
+           nova = client.Client(self.api_version, session=self.session, region_name=self.region_name)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/nova/Services.py
+++ b/openstacknagios/nova/Services.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
     Nagios/Icinga plugin to check running nova services.
@@ -26,37 +26,27 @@ import openstacknagios.openstacknagios as osnag
 
 from novaclient.client import Client
 
-
 class NovaServices(osnag.Resource):
     """
     Determines the status of the nova services.
     """
-
     def __init__(self, binary=None, host=None, args=None):
         self.binary = binary
         self.host   = host
-        self.openstack = self.get_openstack_vars(args=args)
-        osnag.Resource.__init__(self)
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
-
         try:
-           nova=Client('2', self.openstack['username'], 
-                            self.openstack['password'], 
-                            self.openstack['tenant_name'],
-                            auth_url    = self.openstack['auth_url'],
-                            cacert      = self.openstack['cacert'],
-                            region_name = self.openstack['region_name'],
-                            insecure    = self.openstack['insecure'])
+           nova = Client('2', session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 
         try:
-           result=nova.services.list(host=self.host,binary=self.binary)
+           result = nova.services.list(host=self.host, binary=self.binary)
         except Exception as e:
            self.exit_error(str(e))
 
-        stati=dict(up=0, disabled=0, down=0, total=0)
+        stati = dict(up=0, disabled=0, down=0, total=0)
 
         for agent in result:
            stati['total'] += 1
@@ -88,11 +78,11 @@ def main():
     argp.add_argument( '--critical_down', metavar='RANGE', default='0',
                       help='return critical if number of down agents is outside RANGE (default: 0, always critical if any')
 
-    argp.add_argument('--binary', 
+    argp.add_argument('--binary',
                     dest='binary',
                     default=None,
                     help='filter agent binary')
-    argp.add_argument('--host', 
+    argp.add_argument('--host',
                     dest='host',
                     default=None,
                     help='filter hostname')
@@ -105,11 +95,8 @@ def main():
         osnag.ScalarContext('disabled', args.warn_disabled, args.critical_disabled),
         osnag.ScalarContext('down', args.warn_down, args.critical_down),
         osnag.ScalarContext('total', '0:', '@0'),
-        osnag.Summary(show=['up','disabled','down','total'])
-        )
+        osnag.Summary(show=['up','disabled','down','total']))
     check.main(verbose=args.verbose,  timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-
-

--- a/openstacknagios/nova/Services.py
+++ b/openstacknagios/nova/Services.py
@@ -37,7 +37,7 @@ class NovaServices(osnag.Resource):
 
     def probe(self):
         try:
-           nova = Client('2', session=self.session)
+           nova = Client(self.api_version, session=self.session)
         except Exception as e:
            self.exit_error(str(e))
 

--- a/openstacknagios/openstacknagios.py
+++ b/openstacknagios/openstacknagios.py
@@ -36,8 +36,12 @@ class Resource(NagiosResource):
     """
     Base definition of OpenStack Nagios resource
     """
+    DEFAULT_API_VERSION = '2'
+
     def __init__(self, args=None):
         NagiosResource.__init__(self)
+        self.api_version = args.os_api_version or self.DEFAULT_API_VERSION
+
         auth = loading.cli.load_from_argparse_arguments(args)
         sess = loading.session.load_from_argparse_arguments(args)
         # TODO: loading Adapter parameters automatically is not yet supported.
@@ -48,7 +52,7 @@ class Resource(NagiosResource):
             interface=args.os_interface,
             region_name=args.os_region_name,
             endpoint_override=args.os_endpoint_override,
-            version=args.os_api_version)
+            version=self.api_version)
 
     def exit_error(self, text):
        print 'UNKNOWN - ' + text
@@ -76,9 +80,9 @@ class ArgumentParser(ArgArgumentParser):
     def __init__(self, description, epilog=''):
         ArgArgumentParser.__init__(self, description=description, epilog=epilog)
         argv = sys.argv[1:]
-        loading.adapter.register_argparse_arguments(self)
         loading.cli.register_argparse_arguments(self, argv)
         loading.session.register_argparse_arguments(self)
+        loading.adapter.register_argparse_arguments(self)
 
         self.add_argument('-v', '--verbose', action='count', default=0,
                           help='increase output verbosity (use up to 3 times)'

--- a/openstacknagios/openstacknagios.py
+++ b/openstacknagios/openstacknagios.py
@@ -31,16 +31,16 @@ from keystoneauth1 import loading
 from os import environ as env
 import sys
 
+DEFAULT_API_VERSION = '2'
+DEFAULT_AUTH_TYPE = 'v3password'
 
 class Resource(NagiosResource):
     """
     Base definition of OpenStack Nagios resource
     """
-    DEFAULT_API_VERSION = '2'
-
     def __init__(self, args=None):
         NagiosResource.__init__(self)
-        self.api_version = args.os_api_version or self.DEFAULT_API_VERSION
+        self.api_version = args.os_api_version or DEFAULT_API_VERSION
 
         auth = loading.cli.load_from_argparse_arguments(args)
         sess = loading.session.load_from_argparse_arguments(args)
@@ -80,7 +80,7 @@ class ArgumentParser(ArgArgumentParser):
     def __init__(self, description, epilog=''):
         ArgArgumentParser.__init__(self, description=description, epilog=epilog)
         argv = sys.argv[1:]
-        loading.cli.register_argparse_arguments(self, argv)
+        loading.cli.register_argparse_arguments(self, argv, DEFAULT_AUTH_TYPE)
         loading.session.register_argparse_arguments(self)
         loading.adapter.register_argparse_arguments(self)
 

--- a/openstacknagios/openstacknagios.py
+++ b/openstacknagios/openstacknagios.py
@@ -14,71 +14,54 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#   
+#
 
-from nagiosplugin import Resource      as NagiosResource
-from nagiosplugin import Summary       as NagiosSummary
+from nagiosplugin import Resource as NagiosResource
+from nagiosplugin import Summary as NagiosSummary
 from nagiosplugin import Check
 from nagiosplugin import Metric
 from nagiosplugin import guarded
 from nagiosplugin import ScalarContext
 
-from argparse import ArgumentParser    as ArgArgumentParser
+from argparse import ArgumentParser as ArgArgumentParser
+
+from keystoneauth1 import adapter
+from keystoneauth1 import loading
 
 from os import environ as env
 import sys
 
-import ConfigParser
-
 
 class Resource(NagiosResource):
     """
-
-    Openstack specific
-
+    Base definition of OpenStack Nagios resource
     """
-
-    def get_openstack_vars(self,args=None):
-
-       os_vars = dict(username='', password='',tenant_name='',auth_url='', cacert='', region_name='')
-
-       if args.filename:
-          config = ConfigParser.RawConfigParser()
-          config.read(args.filename)
-          try:
-            for r in os_vars.keys():
-               try:
-                 os_vars[r]    = config.get('DEFAULT', r )
-               except:
-                 os_vars[r]    = None
-
-          except Exception as e:
-            self.exit_error(str(e) + ' Filename: ' + args.filename)
-          
-       else:
-          try: 
-            for r in os_vars.keys():
-               os_vars[r]    = env['OS_' + r.upper()]
-          except Exception as e:
-            self.exit_error('missing environment variable ' + str(e))
-
-       os_vars['insecure']=args.insecure
-       return os_vars
+    def __init__(self, args=None):
+        NagiosResource.__init__(self)
+        auth = loading.cli.load_from_argparse_arguments(args)
+        sess = loading.session.load_from_argparse_arguments(args)
+        # TODO: loading Adapter parameters automatically is not yet supported.
+        # This is due to missing functionality in keystoneauth
+        self.session = adapter.Adapter(sess, auth=auth,
+            service_type=args.os_service_type,
+            service_name=args.os_service_name,
+            interface=args.os_interface,
+            region_name=args.os_region_name,
+            endpoint_override=args.os_endpoint_override,
+            version=args.os_api_version)
 
     def exit_error(self, text):
        print 'UNKNOWN - ' + text
        sys.exit(3)
 
 
-
 class Summary(NagiosSummary):
-    """Create status line with info
-
+    """
+    Create status line with info
     """
     def __init__(self, show):
         self.show = show
-        NagiosSummary.__init__(self)
-
+        super(NagiosSummary, self).__init__()
 
     def ok(self, results):
         return '[' + ' '.join(
@@ -90,24 +73,15 @@ class Summary(NagiosSummary):
 
 
 class ArgumentParser(ArgArgumentParser):
+    def __init__(self, description, epilog=''):
+        ArgArgumentParser.__init__(self, description=description, epilog=epilog)
+        argv = sys.argv[1:]
+        loading.adapter.register_argparse_arguments(self)
+        loading.cli.register_argparse_arguments(self, argv)
+        loading.session.register_argparse_arguments(self)
 
-    def __init__(self,description, epilog=''):
-        ArgArgumentParser.__init__(self,description=description, epilog=epilog)
-
-        self.add_argument('--filename',
-                      help='file to read openstack credentials from. If not set it take the environment variables' )
         self.add_argument('-v', '--verbose', action='count', default=0,
-                      help='increase output verbosity (use up to 3 times)'
-                           '(not everywhere implemented)')
-        self.add_argument('--timeout', type=int, default=10,
-                      help='amount of seconds until execution stops with unknown state (default 10 seconds)')
-        self.add_argument('--insecure',
-                      default=False,
-                      action='store_true',
-                      help="Explicitly allow client to perform \"insecure\" "
-                           "SSL (https) requests. The server's certificate will "
-                           "not be verified against any certificate authorities. "
-                           "This option should be used with caution.")
-        self.add_argument('--cacert',
-                      help="Specify a CA bundle file to use in verifying a TLS"
-                           "(https) server certificate.")
+                          help='increase output verbosity (use up to 3 times)'
+                                '(not everywhere implemented)')
+        # self.add_argument('--timeout', type=int, default=10,
+        #                   help='amount of seconds until execution stops with unknown state (default 10 seconds)')

--- a/openstacknagios/openstacknagios.py
+++ b/openstacknagios/openstacknagios.py
@@ -82,6 +82,4 @@ class ArgumentParser(ArgArgumentParser):
 
         self.add_argument('-v', '--verbose', action='count', default=0,
                           help='increase output verbosity (use up to 3 times)'
-                                '(not everywhere implemented)')
-        # self.add_argument('--timeout', type=int, default=10,
-        #                   help='amount of seconds until execution stops with unknown state (default 10 seconds)')
+                               '(not everywhere implemented)')

--- a/openstacknagios/rally/Results.py
+++ b/openstacknagios/rally/Results.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#  
+#
 
 """
   Nagios/Icinga plugin to check rally results.
@@ -22,7 +22,6 @@
   Takes the output of 'rally task results' as input on stdin.
   and calculates the sum of load- and full_duration and the number
   of failed scenarios.
-
 """
 
 import openstacknagios.openstacknagios as osnag
@@ -33,22 +32,20 @@ class RallyResults(osnag.Resource):
     """
     """
 
-    def __init__(self, args=None):
-        if args.resultfile:
-            infile = open(args.resultfile, 'r')
-
+    def __init__(self, result_file=None, args=None):
+        if result_file:
+            infile = open(result_file, 'r')
             with infile:
                 try:
-                    self.results=json.load(infile)
+                    self.results = json.load(infile)
                 except ValueError:
                     raise SystemExit(sys.exc_info()[1])
         else:
-            self.results=json.load(sys.stdin)
+            self.results = json.load(sys.stdin)
 
-        osnag.Resource.__init__(self)
+        osnag.Resource.__init__(self, args)
 
     def probe(self):
-
         full_duration=0
         load_duration=0
         total=0
@@ -67,7 +64,6 @@ class RallyResults(osnag.Resource):
                     if not sla['success']:
                         slafail=slafail+1
 
-
         yield osnag.Metric('total', total)
         yield osnag.Metric('errors', errors )
         yield osnag.Metric('slafail', slafail )
@@ -78,7 +74,7 @@ class RallyResults(osnag.Resource):
 def main():
     argp = osnag.ArgumentParser(description=__doc__)
 
-    argp.add_argument('--resultfile',
+    argp.add_argument('--result_file',
                       help='file to read results from (output of rally task results) if not specified, stdin is used.' )
 
     argp.add_argument('-w', '--warn', metavar='RANGE', default=':0',
@@ -109,17 +105,14 @@ def main():
     args = argp.parse_args()
 
     check = osnag.Check(
-        RallyResults(args=args),
+        RallyResults(result_file=args.result_file, args=args),
         osnag.ScalarContext('errors', args.warn, args.critical),
         osnag.ScalarContext('total', args.warn_total, args.critical_total),
         osnag.ScalarContext('slafail', args.warn_slafail, args.critical_slafail),
         osnag.ScalarContext('fulldur', args.warn_fulldur, args.critical_fulldur),
         osnag.ScalarContext('loaddur', args.warn_loaddur, args.critical_loaddur),
-        osnag.Summary(show=['errors','slafail'])
-        )
+        osnag.Summary(show=['errors','slafail']))
     check.main(verbose=args.verbose, timeout=args.timeout)
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
## Scope

Changes the ad hoc argument parsing logic to leverage the built-in keystoneauth parsing functionality.
This should enable smoother updates to the underlying client implementations while allowing users to take advantage of future interface additions without upgrading these scripts.

## Implementation

The `keystoneauth` module supports parsing and loading arguments relevant to the authentication abstractions, namely the auth plugin, the session, and the adapter (which allows passing in additional flags or configuration to the session, like `region_name`.) Instead of parsing arguments, we now delegate to the "native" OS implementation. All checks now can reference a `self.session` variable that holds the Session instance that has been pre-populated with the configuration.

The API version defaults to '2', and the auth type defaults to 'v3password', which _should_ preserve past behavior, and in the case of auth type, brings this up to the latest standard of TheWayThingsShouldBe(tm).

Also removes the `timeout` flag, which is redundant, as the delegated arg parsing already uses this.
